### PR TITLE
Show ggrc logo

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -24,7 +24,7 @@ exports = []
 
 # Deployment-specific variables
 COMPANY = "Company, Inc."
-COMPANY_LOGO = "<img src='../static/images/ggrc-logo.png'>"
+COMPANY_LOGO = "/static/images/ggrc-logo.png"
 COMPANY_LOGO_TEXT = "Company GRC"
 COPYRIGHT = u"Confidential. Copyright \u00A9"  # \u00A9 is the (c) symbol
 

--- a/src/ggrc/templates/layouts/dashboard.haml
+++ b/src/ggrc/templates/layouts/dashboard.haml
@@ -17,20 +17,13 @@
   %header.header.main
   .area{ 'class': '={ model_display_class }' }
     .header-content
-      .row-fluid
-        #page-header.span12
-          .pull-left
-            %h2
-              %a{ 'class': 'to-my-work', 'href': '/dashboard' }
-                -set logo_url = config.get("COMPANY_LOGO")
-                -set logo_text = config.get("COMPANY_LOGO_TEXT")
-                -if logo_url
-                  %img{ "src" : "#{logo_url}", 'alt' : 'GRC', 'title' : 'GRC'}
-                -elif logo_text != None
-                  =logo_text
-                -else
-                  Google GRC
-          -block header
+
+        %h2
+          %a{ 'class': 'to-my-work', 'href': '/dashboard' }
+            -set logo_url = config.get("COMPANY_LOGO")
+            -if logo_url
+              %img{ "src" : "#{logo_url}", 'alt' : 'GRC', 'title' : 'GRC'}
+        #page-header
 
     .top-inner-nav
       .object-nav


### PR DESCRIPTION
Hey @vladan-m this makes the logo visible, but there are a few issues:
1. Everything in #page-header gets replaced on the client side, so we shouldn't have any content there.
2. I removed .rowfluid, because the logo should probably be of a fixed width, also I don't think having .rowfluid with a single span12 element makes sense.
3. My solution breaks the header into two lines, but you can probably fix that, right?
