### PR TITLE
QUICK-FIX Fix tab bar and filter bar on smaller resolutions

### DIFF
--- a/src/ggrc/assets/javascripts/dashboard.js
+++ b/src/ggrc/assets/javascripts/dashboard.js
@@ -450,8 +450,6 @@ function resize_areas(event, target_info_pin_height) {
   $bar.css("height",lhsHeight);
   $footer.css("margin-top",footerMargin);
   $innerNav.css("height",internavHeight);
-  $header.css("width",headerWidth);
-  $topNav.css("width",objectWidth);
   $objectArea
     .css("margin-left",internavWidth)
     .css("height",internavHeight)

--- a/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
@@ -8,8 +8,8 @@
   <div class="sticky sticky-header filter-holder" {{#filter_is_hidden}}style="height: 0px; margin-bottom: 0px;"{{/filter_is_hidden}} data-height="42" data-margin-bottom="25">
     <div class="sticky-filter inner-filter-sticky">
       <div class="inline-filtering" {{ (el) -> el.ggrc_controllers_tree_filter() }} >
-        <div class="row-fluid">
-          <div class="span2">
+
+        <div style="width:10%; float:left;">
             <div class="filter-title">
               <h6>
                 Filter
@@ -18,16 +18,16 @@
                 {{/instance}}
               </h6>
             </div>
-          </div>
-          <div class="span8">
+        </div>
+        <div style="width:50%; float:left;">
             <div class="filter-input">
               <input name="filter_query" type="text" class="input-wide">
               <span class="is-expression">
                 <i class="grcicon-expression-black"></i>
               </span>
             </div>
-          </div>
-          <div class="span2">
+        </div>
+        <div style="width:40%; float:left; overflow:hidden; height:36px;">
             <div class="filter-button">
               <a id="page-help" class="popover-template" data-get-template="help/filters_helper_content" href="javascript://">
                 <i class="grcicon-help-black"></i>
@@ -35,7 +35,6 @@
               <input type="reset" class="btn btn-small btn-draft" name="" value="Reset">
               <input type="submit" class="btn btn-small btn-info" name="" value="Filter">
             </div>
-          </div>
         </div>
       </div>
     </div>

--- a/src/ggrc/assets/stylesheets/_layout.scss
+++ b/src/ggrc/assets/stylesheets/_layout.scss
@@ -49,18 +49,13 @@
 .top-inner-nav {
   @include box-shadow(inset 1px 4px 9px -6px rgba(0,0,0,0.4));
   width: 100%;
-  height: 29px;
-  position: fixed;
   z-index: 1;
   top: 48px;
   background: $tabBgnd;
 }
 .object-area {
-  position:fixed;
-  top: 78px;
   overflow-y:auto;
   overflow-x:hidden;
-  height: 493px;
   padding-top: 20px;
   background: $contentBgnd;
   &.import-area {

--- a/src/ggrc/assets/stylesheets/_lhs.scss
+++ b/src/ggrc/assets/stylesheets/_lhs.scss
@@ -32,6 +32,7 @@ h4.search-title {
   position:relative;
   padding-left: 10px;
   padding-right: 4px;
+  z-index: 2;
   .lhs-bg {
     @include opacity(0.6);
     margin-top:5px;

--- a/src/ggrc/assets/stylesheets/_responsive.scss
+++ b/src/ggrc/assets/stylesheets/_responsive.scss
@@ -269,10 +269,6 @@
     text-align:left;
   }
 
-  .content {
-    background: $white;
-  }
-
   .lhs-nav {
     ul.sub-level {
       li {

--- a/src/ggrc/assets/stylesheets/_setup.scss
+++ b/src/ggrc/assets/stylesheets/_setup.scss
@@ -235,7 +235,7 @@ $fontTitle: "Helvetica Neue", Helvetica, Arial, sans-serif;
 %sticky {
   position: -webkit-sticky;
   position: sticky;
-  z-index: 999;
+  z-index: 1;
   top: 0;
 }
 

--- a/src/ggrc/static/mockups/js/lhn-controller.js
+++ b/src/ggrc/static/mockups/js/lhn-controller.js
@@ -13,7 +13,6 @@ function resize_areas() {
   ,   $lhs
   ,   $lhsHolder
   ,   $area
-  ,   $header
   ,   $footer
   ,   $innerNav
   ,   $objectArea
@@ -31,7 +30,6 @@ function resize_areas() {
   $lhs = $(".lhs");
   $lhsHolder = $(".lhs-holder");
   $footer = $(".footer");
-  $header = $(".header-content");
   $innerNav = $(".inner-nav");
   $objectArea = $(".object-area");
   $area = $(".area");
@@ -52,7 +50,6 @@ function resize_areas() {
   $bar.css("height",lhsHeight);
   $footer.css("margin-top",footerMargin);
   $innerNav.css("height",internavHeight);
-  $header.css("width",headerWidth);
   $objectArea
     .css("margin-left",internavWidth)
     .css("height",internavHeight -30)


### PR DESCRIPTION
This basically changes our app from this:

![screen shot 2015-09-08 at 15 37 49](https://cloud.githubusercontent.com/assets/513444/9736211/3427734a-5640-11e5-886c-d258df5e06b4.png)

To this:

![screen shot 2015-09-08 at 15 39 52](https://cloud.githubusercontent.com/assets/513444/9736213/3684019e-5640-11e5-8ab4-6fa8db2fc016.png)

@vladan-m can you just move the inline styles in `tree_view_filter.mustache` into an appropriate file?
